### PR TITLE
fix termination for FLP2EPN examples

### DIFF
--- a/example/flp2epn-dynamic/O2EPNex.cxx
+++ b/example/flp2epn-dynamic/O2EPNex.cxx
@@ -64,6 +64,13 @@ void O2EPNex::Run()
 
   rateLogger.interrupt();
   rateLogger.join();
+
+  FairMQDevice::Shutdown();
+
+  // notify parent thread about end of processing.
+  boost::lock_guard<boost::mutex> lock(fRunningMutex);
+  fRunningFinished = true;
+  fRunningCondition.notify_one();
 }
 
 O2EPNex::~O2EPNex()

--- a/example/flp2epn-dynamic/O2FLPex.cxx
+++ b/example/flp2epn-dynamic/O2FLPex.cxx
@@ -128,6 +128,13 @@ void O2FLPex::Run()
   rateLogger.interrupt();
 
   rateLogger.join();
+
+  FairMQDevice::Shutdown();
+
+  // notify parent thread about end of processing.
+  boost::lock_guard<boost::mutex> lock(fRunningMutex);
+  fRunningFinished = true;
+  fRunningCondition.notify_one();
 }
 
 void O2FLPex::Log(int intervalInMs)

--- a/example/flp2epn-dynamic/run/runEPN_dynamic.cxx
+++ b/example/flp2epn-dynamic/run/runEPN_dynamic.cxx
@@ -120,8 +120,12 @@ int main(int argc, char** argv)
   epn.ChangeState(O2EPNex::SETINPUT);
   epn.ChangeState(O2EPNex::RUN);
 
-  char ch;
-  cin.get(ch);
+  // wait until the running thread has finished processing.
+  boost::unique_lock<boost::mutex> lock(epn.fRunningMutex);
+  while (!epn.fRunningFinished)
+  {
+      epn.fRunningCondition.wait(lock);
+  }
 
   epn.ChangeState(O2EPNex::STOP);
   epn.ChangeState(O2EPNex::END);

--- a/example/flp2epn-dynamic/run/runFLP_dynamic.cxx
+++ b/example/flp2epn-dynamic/run/runFLP_dynamic.cxx
@@ -128,8 +128,12 @@ int main(int argc, char** argv)
   flp.ChangeState(O2FLPex::SETINPUT);
   flp.ChangeState(O2FLPex::RUN);
 
-  char ch;
-  cin.get(ch);
+  // wait until the running thread has finished processing.
+  boost::unique_lock<boost::mutex> lock(flp.fRunningMutex);
+  while (!flp.fRunningFinished)
+  {
+      flp.fRunningCondition.wait(lock);
+  }
 
   flp.ChangeState(O2FLPex::STOP);
   flp.ChangeState(O2FLPex::END);

--- a/example/flp2epn/O2EPNex.cxx
+++ b/example/flp2epn/O2EPNex.cxx
@@ -39,6 +39,13 @@ void O2EPNex::Run()
 
   rateLogger.interrupt();
   rateLogger.join();
+
+  FairMQDevice::Shutdown();
+
+  // notify parent thread about end of processing.
+  boost::lock_guard<boost::mutex> lock(fRunningMutex);
+  fRunningFinished = true;
+  fRunningCondition.notify_one();
 }
 
 O2EPNex::~O2EPNex()

--- a/example/flp2epn/O2EpnMerger.cxx
+++ b/example/flp2epn/O2EpnMerger.cxx
@@ -76,6 +76,13 @@ void O2EpnMerger::Run()
 
   rateLogger.interrupt();
   rateLogger.join();
+
+  FairMQDevice::Shutdown();
+
+  // notify parent thread about end of processing.
+  boost::lock_guard<boost::mutex> lock(fRunningMutex);
+  fRunningFinished = true;
+  fRunningCondition.notify_one();
 }
 
 O2EpnMerger::~O2EpnMerger()

--- a/example/flp2epn/O2FLPex.cxx
+++ b/example/flp2epn/O2FLPex.cxx
@@ -66,6 +66,13 @@ void O2FLPex::Run()
   rateLogger.interrupt();
 
   rateLogger.join();
+
+  FairMQDevice::Shutdown();
+
+  // notify parent thread about end of processing.
+  boost::lock_guard<boost::mutex> lock(fRunningMutex);
+  fRunningFinished = true;
+  fRunningCondition.notify_one();
 }
 
 void O2FLPex::Log(int intervalInMs)

--- a/example/flp2epn/O2Merger.cxx
+++ b/example/flp2epn/O2Merger.cxx
@@ -59,5 +59,12 @@ void O2Merger::Run()
 
   rateLogger.interrupt();
   rateLogger.join();
+
+  FairMQDevice::Shutdown();
+
+  // notify parent thread about end of processing.
+  boost::lock_guard<boost::mutex> lock(fRunningMutex);
+  fRunningFinished = true;
+  fRunningCondition.notify_one();
 }
 

--- a/example/flp2epn/O2Proxy.cxx
+++ b/example/flp2epn/O2Proxy.cxx
@@ -51,4 +51,11 @@ void O2Proxy::Run()
 
   rateLogger.interrupt();
   rateLogger.join();
+
+  FairMQDevice::Shutdown();
+
+  // notify parent thread about end of processing.
+  boost::lock_guard<boost::mutex> lock(fRunningMutex);
+  fRunningFinished = true;
+  fRunningCondition.notify_one();
 }

--- a/example/flp2epn/run/runEPN.cxx
+++ b/example/flp2epn/run/runEPN.cxx
@@ -100,9 +100,12 @@ int main(int argc, char** argv)
   epn.ChangeState(O2EPNex::SETINPUT);
   epn.ChangeState(O2EPNex::RUN);
 
-
-  char ch;
-  cin.get(ch);
+  // wait until the running thread has finished processing.
+  boost::unique_lock<boost::mutex> lock(epn.fRunningMutex);
+  while (!epn.fRunningFinished)
+  {
+      epn.fRunningCondition.wait(lock);
+  }
 
   epn.ChangeState(O2EPNex::STOP);
   epn.ChangeState(O2EPNex::END);

--- a/example/flp2epn/run/runEPN_M.cxx
+++ b/example/flp2epn/run/runEPN_M.cxx
@@ -100,9 +100,12 @@ int main(int argc, char** argv)
   epn.ChangeState(O2EpnMerger::SETINPUT);
   epn.ChangeState(O2EpnMerger::RUN);
 
-
-  char ch;
-  cin.get(ch);
+  // wait until the running thread has finished processing.
+  boost::unique_lock<boost::mutex> lock(epn.fRunningMutex);
+  while (!epn.fRunningFinished)
+  {
+      epn.fRunningCondition.wait(lock);
+  }
 
   epn.ChangeState(O2EpnMerger::STOP);
   epn.ChangeState(O2EpnMerger::END);

--- a/example/flp2epn/run/runFLP.cxx
+++ b/example/flp2epn/run/runFLP.cxx
@@ -101,8 +101,12 @@ int main(int argc, char** argv)
   flp.ChangeState(O2FLPex::SETINPUT);
   flp.ChangeState(O2FLPex::RUN);
 
-  char ch;
-  cin.get(ch);
+  // wait until the running thread has finished processing.
+  boost::unique_lock<boost::mutex> lock(flp.fRunningMutex);
+  while (!flp.fRunningFinished)
+  {
+      flp.fRunningCondition.wait(lock);
+  }
 
   flp.ChangeState(O2FLPex::STOP);
   flp.ChangeState(O2FLPex::END);

--- a/example/flp2epn/run/runMerger.cxx
+++ b/example/flp2epn/run/runMerger.cxx
@@ -117,9 +117,12 @@ int main(int argc, char** argv)
   merger.ChangeState(O2Merger::SETINPUT);
   merger.ChangeState(O2Merger::RUN);
 
-
-  char ch;
-  cin.get(ch);
+  // wait until the running thread has finished processing.
+  boost::unique_lock<boost::mutex> lock(merger.fRunningMutex);
+  while (!merger.fRunningFinished)
+  {
+      merger.fRunningCondition.wait(lock);
+  }
 
   merger.ChangeState(O2Merger::STOP);
   merger.ChangeState(O2Merger::END);

--- a/example/flp2epn/run/runProxy.cxx
+++ b/example/flp2epn/run/runProxy.cxx
@@ -112,8 +112,12 @@ int main(int argc, char** argv)
   proxy.ChangeState(O2Proxy::RUN);
 
 
-  char ch;
-  cin.get(ch);
+  // wait until the running thread has finished processing.
+  boost::unique_lock<boost::mutex> lock(proxy.fRunningMutex);
+  while (!proxy.fRunningFinished)
+  {
+      proxy.fRunningCondition.wait(lock);
+  }
 
   proxy.ChangeState(O2Proxy::STOP);
   proxy.ChangeState(O2Proxy::END);

--- a/fairmq/FairMQStateMachine.cxx
+++ b/fairmq/FairMQStateMachine.cxx
@@ -59,6 +59,4 @@ void FairMQStateMachine::ChangeState(int event)
     {
         LOG(ERROR) << e.what();
     }
-
-
-    }
+}


### PR DESCRIPTION
This commit fixes the termination issues for the examples FLP2EPN and FLP2EPN-dynamic.
